### PR TITLE
Fix segfault on winpcap connect.

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -1548,7 +1548,7 @@ void daemon_seraddr(struct sockaddr_storage *sockaddrin, struct sockaddr_storage
 		sockaddr->sin_port= htons(sockaddr->sin_port);
 		memcpy(sockaddrout, sockaddr, sizeof(struct sockaddr_in) );
 	}
-	else
+	else if (sockaddrin->ss_family == AF_INET6)
 	{
 	struct sockaddr_in6 *sockaddr;
 	


### PR DESCRIPTION
Your description says:
"There are two ways to connect from a Windows box. One is to use GUI in Wireshark Capture Options dialog, but it's not cool and sometimes causes rpcapd child process to segfault during interface discovery."

This is a fix for this based on the following patch: 
http://www.mail-archive.com/winpcap-users@winpcap.org/msg01215.html
